### PR TITLE
feat: tbxmanager publish command, issue-based submission, test coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   lint:
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -34,6 +35,7 @@ jobs:
           uv run --group dev check-jsonschema --schemafile scripts/schemas/lockfile.schema.json tests/fixtures/valid_lockfile.json
 
   matlab:
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ __pycache__/
 *.pyc
 .venv/
 *.egg-info/
+
+# Environment variables
+.env

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Full documentation at [tbxmanager.com](https://tbxmanager.com):
 
 ### Packages
 
-[Submit packages](https://github.com/MarekWadinger/tbxmanager-registry/issues/new?template=submit-package.yml) via the registry issue form. Registry collaborators can also use the [tbxmanager-publish](https://github.com/MarekWadinger/tbxmanager-publish) action for automation.
+[Submit packages](https://github.com/MarekWadinger/tbxmanager-registry/issues/new?template=submit-package.yml) via the registry issue form, or run `tbxmanager publish` from your package directory.
 
 ### Client
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ tbxmanager info mpt             % Package details
 - **Lockfiles** — `tbxmanager lock` + `tbxmanager sync` for reproducible environments
 - **SHA256 verification** — every download verified for integrity
 - **Cross-platform** — Windows, macOS (Intel & Apple Silicon), Linux
-- **Community registry** — open package submissions via pull request
-- **Automated publishing** — tag a release, and the [publish action](https://github.com/MarekWadinger/tbxmanager-publish) handles the rest
+- **Community registry** — [submit packages](https://github.com/MarekWadinger/tbxmanager-registry/issues/new?template=submit-package.yml) by filling in a form
 
 ## Commands
 
@@ -64,8 +63,8 @@ tbxmanager info mpt             % Package details
 ## Publish Your Package
 
 1. Add `tbxmanager.json` to your repo (or run `tbxmanager init`)
-2. Copy the [publish workflow](https://github.com/MarekWadinger/tbxmanager-publish/blob/main/example-workflow.yml) to `.github/workflows/`
-3. Tag a release — the action builds archives, computes SHA256, and opens a PR to the registry
+1. Create a GitHub Release with a zip archive of your package
+1. [Submit via the registry issue form](https://github.com/MarekWadinger/tbxmanager-registry/issues/new?template=submit-package.yml) — a bot handles SHA256, validation, and the PR
 
 See the [Quick Start for Authors](https://tbxmanager.com/quick-start-authors) for the full guide.
 
@@ -84,7 +83,7 @@ Full documentation at [tbxmanager.com](https://tbxmanager.com):
 
 ### Packages
 
-Publish packages using the [tbxmanager-publish](https://github.com/MarekWadinger/tbxmanager-publish) GitHub Action, or submit manually to the [tbxmanager-registry](https://github.com/MarekWadinger/tbxmanager-registry) via pull request.
+[Submit packages](https://github.com/MarekWadinger/tbxmanager-registry/issues/new?template=submit-package.yml) via the registry issue form. Registry collaborators can also use the [tbxmanager-publish](https://github.com/MarekWadinger/tbxmanager-publish) action for automation.
 
 ### Client
 

--- a/docs/casestudy.md
+++ b/docs/casestudy.md
@@ -91,113 +91,80 @@ Check which features your code uses:
 
 Pick the highest minimum from features you use. For RLS_identification, `arguments` blocks require **R2019b**.
 
-## Step 2: Add the Publish Workflow
-
-Create `.github/workflows/tbxmanager-publish.yml`:
-
-```yaml
-name: Publish to tbxmanager
-
-on:
-  release:
-    types: [published]
-
-jobs:
-  publish:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: MarekWadinger/tbxmanager-publish@v1
-        with:
-          registry-token: ${{ secrets.TBXMANAGER_REGISTRY_TOKEN }}
-```
-
-That's the entire workflow -- 15 lines. It triggers when you create a GitHub Release.
-
-## Step 3: Create a Registry Token
-
-The publish action needs permission to open PRs on the tbxmanager registry. You create this once and reuse it across all your packages.
-
-1. Go to [GitHub Settings > Developer settings > Personal access tokens > Fine-grained tokens](https://github.com/settings/personal-access-tokens/new)
-2. Create a new token with:
-    - **Token name:** `tbxmanager-publish`
-    - **Expiration:** 1 year (or your preference)
-    - **Repository access:** Select `MarekWadinger/tbxmanager-registry`
-    - **Permissions:** Contents (Read and write), Pull requests (Read and write)
-3. Copy the token
-4. Go to your package repo: **Settings > Secrets and variables > Actions**
-5. Click **New repository secret**
-    - **Name:** `TBXMANAGER_REGISTRY_TOKEN`
-    - **Value:** paste the token
-
-## Step 4: Commit and Push
+## Step 2: Commit and Push
 
 ```bash
 cd RLS_identification
 
-git add tbxmanager.json .github/workflows/tbxmanager-publish.yml
-git commit -m "feat: add tbxmanager package publishing"
+git add tbxmanager.json
+git commit -m "feat: add tbxmanager package metadata"
 git push
 ```
 
-## Step 5: Create a Release
+That's the only file you need to add to your repo.
 
-### Option A: GitHub CLI
+## Step 3: Create a GitHub Release
 
-```bash
-git tag v1.0.0
-git push --tags
-gh release create v1.0.0 --title "v1.0.0" --notes "Initial tbxmanager release"
-```
+1. Zip your package (exclude `.git`, tests, data files you don't want distributed):
 
-### Option B: GitHub Web UI
+    ```bash
+    zip -r rls-identification.zip functions/ main.m LICENSE README.md
+    ```
 
-1. Go to your repo on GitHub
-2. Click **Releases** > **Create a new release**
-3. Choose tag: type `v1.0.0`, select "Create new tag on publish"
-4. Title: `v1.0.0`
-5. Click **Publish release**
+1. Tag and push:
+
+    ```bash
+    git tag v1.0.0
+    git push --tags
+    ```
+
+1. Go to your repo on GitHub, click **Releases** > **Create a new release**
+1. Select the `v1.0.0` tag, add a title
+1. **Attach `rls-identification.zip`** as a release asset
+1. Click **Publish release**
+
+## Step 4: Submit to the Registry
+
+1. Go to [tbxmanager-registry > Issues > New Issue](https://github.com/MarekWadinger/tbxmanager-registry/issues/new/choose)
+1. Click **"Submit Package"**
+1. Fill in:
+    - **Repository URL:** `https://github.com/MarekWadinger/RLS_identification`
+    - **Release tag:** `v1.0.0`
+    - **Platform:** `all (pure MATLAB, no MEX files)`
+1. Click **Submit new issue**
 
 ## What Happens Automatically
 
-After you publish the release, the GitHub Action runs and does everything else:
+After you submit the issue, a bot takes over:
 
 ```text
-You: Create GitHub Release v1.0.0
+You: Fill in the submission form
          |
          v
-Action: Reads tbxmanager.json
+Bot: Fetches tbxmanager.json from your repo at v1.0.0
   name = rls-identification
   version = 1.0.0
          |
          v
-Action: Builds rls-identification-all.zip
-  Includes: functions/, main.m, LICENSE, README.md
-  Excludes: .git, .github, *.mat, *.slx
+Bot: Downloads rls-identification.zip from your release
          |
          v
-Action: Uploads zip to release assets
-  URL: github.com/MarekWadinger/RLS_identification/releases/download/v1.0.0/rls-identification-all.zip
-         |
-         v
-Action: Computes SHA256 hash
+Bot: Computes SHA256 hash
   sha256 = a1b2c3d4...
          |
          v
-Action: Converts tbxmanager.json to registry format
+Bot: Converts tbxmanager.json to registry format
   Creates packages/rls-identification/package.json
          |
          v
-Action: Opens PR to MarekWadinger/tbxmanager-registry
-  Title: "New package: rls-identification@1.0.0"
+Bot: Opens PR to MarekWadinger/tbxmanager-registry
+  Title: "Add rls-identification@1.0.0"
          |
          v
-Registry CI: Validates JSON schema, checks URL, verifies SHA256
+Registry CI: Validates JSON, checks URL
          |
          v
-Maintainer merges PR (auto-merge for updates after first approval)
+Maintainer merges PR
          |
          v
 Package is live!
@@ -229,16 +196,9 @@ rls-identification 1.0.0
 When you improve your package:
 
 1. Update `version` in `tbxmanager.json` (e.g., `1.0.0` -> `1.1.0`)
-2. Commit and push your changes
-3. Create a new release:
-
-```bash
-git tag v1.1.0
-git push --tags
-gh release create v1.1.0 --title "v1.1.0" --notes "Added feature X"
-```
-
-The action opens a new PR to the registry. Since the package already exists, it gets auto-merged (no manual review needed).
+1. Commit and push your changes
+1. Create a new release with the updated zip
+1. Submit another issue on the registry (same form, new tag)
 
 Users update with:
 
@@ -248,13 +208,10 @@ Users update with:
 
 ## Repository Structure (After)
 
-After adding tbxmanager support, only 2 files were added:
+After adding tbxmanager support, only 1 file was added:
 
 ```text
 RLS_identification/
-  .github/
-    workflows/
-      tbxmanager-publish.yml   <-- NEW (15 lines)
   functions/
     preprocessData.m
     recursiveLeastSquares.m
@@ -268,7 +225,7 @@ RLS_identification/
   tbxmanager.json              <-- NEW (14 lines)
 ```
 
-No changes to any existing files. No build system. No CI configuration beyond the 15-line workflow.
+No changes to any existing files. No build system. No CI configuration needed.
 
 ## Common Questions
 
@@ -308,7 +265,7 @@ dist/
   my-package-glnxa64.zip
 ```
 
-The action uploads each platform archive separately.
+Attach all archives to your GitHub Release. Select the corresponding platform in the submission form.
 
 ### I want to deprecate my package
 
@@ -336,18 +293,16 @@ Create a new fine-grained token (Step 3) and update the `TBXMANAGER_REGISTRY_TOK
 
 ### The action failed
 
-Check the Actions tab in your repo. Common issues:
+Check the bot's comment on your submission issue. Common issues:
 
-- **`tbxmanager.json not found`** -- file must be in the repo root
-- **`Archive not found`** -- for platform-specific packages, pre-build archives in `dist/`
-- **`403 on PR creation`** -- token lacks write permissions to the registry
-- **`SHA256 mismatch`** -- re-run the release (archive was modified between upload and hash)
+- **`tbxmanager.json not found`** -- file must be in the repo root at the tagged commit
+- **`No release found`** -- create a GitHub Release for the tag first
+- **`No archive attached`** -- attach a `.zip` file to your GitHub Release
 
 ## Summary
 
 | What | Where | How often |
 | ---- | ----- | --------- |
 | `tbxmanager.json` | Your repo root | Once (update `version` per release) |
-| Publish workflow | `.github/workflows/` | Once (copy and forget) |
-| Registry token | Repo secret | Once (renew when expired) |
-| Create release | GitHub UI or CLI | Each time you publish |
+| Create release + zip | GitHub Releases | Each time you publish |
+| Submit issue | tbxmanager-registry | Each time you publish |

--- a/docs/creating-packages.md
+++ b/docs/creating-packages.md
@@ -2,7 +2,7 @@
 
 ## The Fast Way: Automated Publishing
 
-The easiest way to publish a MATLAB package is with the [tbxmanager-publish](https://github.com/MarekWadinger/tbxmanager-publish) GitHub Action. See the [Quick Start](quick-start-authors.md) for a 3-step guide.
+The easiest way to publish a MATLAB package is to run `tbxmanager publish` from your package directory. Alternatively, [submit via the registry issue form](https://github.com/MarekWadinger/tbxmanager-registry/issues/new?template=submit-package.yml). See the [Quick Start](quick-start-authors.md) for a full guide.
 
 With the publish action, you only maintain `tbxmanager.json` in your repo — the action handles archive building, SHA256 hashing, and registry submission automatically.
 

--- a/docs/quick-start-authors.md
+++ b/docs/quick-start-authors.md
@@ -100,9 +100,16 @@ If your package includes compiled MEX files, create separate archives per platfo
 
 Attach all of them to your GitHub Release and select the appropriate platform in the submission form.
 
-## For Registry Collaborators: Automated Publishing
+## Even Faster: `tbxmanager publish`
 
-If you have write access to the registry, you can fully automate publishing using the [tbxmanager-publish](https://github.com/MarekWadinger/tbxmanager-publish) GitHub Action. See the [Case Study](casestudy.md) for a walkthrough.
+If you have tbxmanager installed, you can do everything in one command:
+
+```matlab
+>> cd my-toolbox
+>> tbxmanager publish
+```
+
+This builds the archive, creates the GitHub release, uploads it, and submits to the registry — all automatically. Requires a GitHub token with `public_repo` scope (prompted on first use).
 
 ## Next Steps
 

--- a/docs/quick-start-authors.md
+++ b/docs/quick-start-authors.md
@@ -19,95 +19,61 @@ Then edit the generated `tbxmanager.json` to match your package:
   "name": "my-toolbox",
   "version": "1.0.0",
   "description": "A useful MATLAB toolbox",
+  "authors": ["YourGitHubUsername"],
+  "license": "MIT",
+  "homepage": "https://github.com/you/my-toolbox",
+  "matlab": ">=R2022a",
   "platforms": {
-    "all": ""
-  }
+    "all": {}
+  },
+  "dependencies": {}
 }
 ```
 
 !!! tip
-    You can also create `tbxmanager.json` manually if you don't have tbxmanager installed yet.
+    You can also create `tbxmanager.json` by hand if you don't have tbxmanager installed yet.
 
 Set `platforms` to `"all"` for pure MATLAB packages. If you distribute compiled MEX files, use platform-specific keys (`win64`, `maci64`, `maca64`, `glnxa64`) instead.
 
-The `platforms` URLs will be filled in automatically by the publish action — leave them empty or as placeholders.
+## Step 2: Create a GitHub Release
 
-## Step 2: Add the Publish Workflow
+1. Zip your package (exclude `.git`, tests, docs, etc.)
+1. Tag your version and push:
 
-Copy this file to `.github/workflows/tbxmanager-publish.yml`:
+    ```bash
+    git tag v1.0.0
+    git push --tags
+    ```
 
-```yaml
-name: Publish to tbxmanager
+1. Go to your repo on GitHub, click **Releases** > **Create a new release**
+1. Select the tag, add a title, and **attach your zip file** as a release asset
+1. Click **Publish release**
 
-on:
-  release:
-    types: [published]
+## Step 3: Submit to the Registry
 
-jobs:
-  publish:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: MarekWadinger/tbxmanager-publish@v1
-        with:
-          registry-token: ${{ secrets.TBXMANAGER_REGISTRY_TOKEN }}
-```
+1. Go to [tbxmanager-registry > Issues > New Issue](https://github.com/MarekWadinger/tbxmanager-registry/issues/new/choose)
+1. Click **"Submit Package"**
+1. Fill in your **Repository URL** and **Release tag**
+1. Click **Submit new issue**
 
-Then add a `TBXMANAGER_REGISTRY_TOKEN` secret to your repo (Settings > Secrets). This should be a GitHub Personal Access Token with permission to create PRs on the [tbxmanager-registry](https://github.com/MarekWadinger/tbxmanager-registry).
+That's it! A bot will automatically:
 
-## Step 3: Create a Release
+- Fetch your `tbxmanager.json`
+- Download your release archive
+- Compute the SHA256 hash
+- Create a pull request to the registry
 
-```bash
-git tag v1.0.0
-git push --tags
-```
-
-Then create a GitHub Release from the tag. The publish action will automatically:
-
-1. Build a zip archive of your package
-2. Upload it to the release
-3. Compute SHA256 hashes
-4. Open a PR to the tbxmanager registry
-
-Once the PR is merged, your package is live:
+Once a maintainer merges the PR, your package is live:
 
 ```matlab
 tbxmanager install my-toolbox
 ```
 
-## What Happens Next
-
-```text
-git tag v1.0.0 && git push --tags
-         |
-         v
-  Create GitHub Release
-         |
-         v
-  tbxmanager-publish action runs:
-    - Builds zip from repo (excluding .git, tests, docs)
-    - Uploads archive to release assets
-    - Computes SHA256 hash
-    - Converts tbxmanager.json to registry format
-    - Opens PR to MarekWadinger/tbxmanager-registry
-         |
-         v
-  CI validates (JSON, URLs, SHA256)
-         |
-         v
-  Merged (auto for updates, reviewed for first submission)
-         |
-         v
-  Package appears in: tbxmanager search my-toolbox
-```
-
 ## Updating Your Package
 
 1. Update `version` in `tbxmanager.json`
-2. Tag and release: `git tag v1.1.0 && git push --tags`
-3. Create a GitHub Release — the action handles the rest
+1. Create a new release with the updated archive
+1. Submit another issue on the registry (same form)
 
 New versions are added alongside existing ones. Users can install specific versions with `tbxmanager install my-toolbox@>=1.1`.
 
@@ -117,10 +83,6 @@ Add a `publish` section to `tbxmanager.json` to control what goes into the archi
 
 ```json
 {
-  "name": "my-toolbox",
-  "version": "1.0.0",
-  "description": "A useful MATLAB toolbox",
-  "platforms": { "all": "" },
   "publish": {
     "exclude": [".git", ".github", "tests", "docs", "benchmarks"]
   }
@@ -129,31 +91,21 @@ Add a `publish` section to `tbxmanager.json` to control what goes into the archi
 
 ## MEX Packages (Platform-Specific)
 
-If your package includes compiled MEX files, you need to pre-build archives for each platform:
+If your package includes compiled MEX files, create separate archives per platform:
 
-1. Build MEX files for each target platform
-2. Create archives in a `dist/` directory:
-    - `dist/my-toolbox-win64.zip`
-    - `dist/my-toolbox-maci64.zip`
-    - `dist/my-toolbox-maca64.zip`
-    - `dist/my-toolbox-glnxa64.zip`
-3. Update `tbxmanager.json`:
+- `my-toolbox-win64.zip`
+- `my-toolbox-maci64.zip`
+- `my-toolbox-maca64.zip`
+- `my-toolbox-glnxa64.zip`
 
-```json
-{
-  "platforms": {
-    "win64": "",
-    "maci64": "",
-    "maca64": "",
-    "glnxa64": ""
-  }
-}
-```
+Attach all of them to your GitHub Release and select the appropriate platform in the submission form.
 
-The publish action will upload these archives and compute SHA256 hashes automatically.
+## For Registry Collaborators: Automated Publishing
+
+If you have write access to the registry, you can fully automate publishing using the [tbxmanager-publish](https://github.com/MarekWadinger/tbxmanager-publish) GitHub Action. See the [Case Study](casestudy.md) for a walkthrough.
 
 ## Next Steps
 
+- [Case Study](casestudy.md) -- real-world example with RLS_identification
 - [Full metadata reference](creating-packages.md) for all `tbxmanager.json` fields
 - [Commands reference](commands.md) for all tbxmanager CLI commands
-- [Contributing](contributing.md) to learn about the registry structure

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -106,4 +106,4 @@ tbxmanager install my-toolbox@==1.0.0
 
 - **tbxmanager client issues:** [MarekWadinger/tbxmanager](https://github.com/MarekWadinger/tbxmanager/issues)
 - **Registry/package issues:** [MarekWadinger/tbxmanager-registry](https://github.com/MarekWadinger/tbxmanager-registry/issues)
-- **Publish action issues:** [MarekWadinger/tbxmanager-publish](https://github.com/MarekWadinger/tbxmanager-publish/issues)
+- **Publishing issues:** run `tbxmanager help publish` or [submit via issue form](https://github.com/MarekWadinger/tbxmanager-registry/issues/new?template=submit-package.yml)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
   - Commands: commands.md
   - For Package Authors:
     - Quick Start: quick-start-authors.md
+    - Case Study: casestudy.md
     - Creating Packages: creating-packages.md
   - Contributing: contributing.md
   - Troubleshooting: troubleshooting.md

--- a/scripts/schemas/tbxmanager-package.schema.json
+++ b/scripts/schemas/tbxmanager-package.schema.json
@@ -67,7 +67,7 @@
     },
     "publish": {
       "type": "object",
-      "description": "Publishing configuration (used by tbxmanager-publish action, ignored by MATLAB client)",
+      "description": "Publishing configuration (used by tbxmanager publish command)",
       "properties": {
         "exclude": {
           "type": "array",

--- a/tbxmanager.m
+++ b/tbxmanager.m
@@ -2671,6 +2671,9 @@ function result = main_internal(args)
             result = true;
         case "toposort"
             result = tbx_toposort(jsondecode(funcArgs(1)));
+        case "buildArchive"
+            tbx_buildArchive(funcArgs(1), funcArgs(2:end));
+            result = true;
         otherwise
             error("TBXMANAGER:Internal", "Unknown internal function: %s", funcName);
     end
@@ -2762,6 +2765,12 @@ function tbx_migrateOld()
     selfDir = fileparts(selfPath);
     oldToolboxDir = fullfile(selfDir, "toolboxes");
     if ~isfolder(oldToolboxDir)
+        return;
+    end
+    % Skip if toolboxes dir is empty (no packages to migrate)
+    contents = dir(oldToolboxDir);
+    contents = contents(~ismember({contents.name}, {'.', '..'}));
+    if isempty(contents)
         return;
     end
 

--- a/tbxmanager.m
+++ b/tbxmanager.m
@@ -65,6 +65,8 @@ function varargout = tbxmanager(command, varargin)
             main_require(args);
         case "cache"
             main_cache(args);
+        case "publish"
+            main_publish(args);
         case "help"
             main_help(args);
         case "internal__"
@@ -1954,7 +1956,7 @@ function main_init(~)
     tbx_writeJson(projectFile, project);
     tbx_printf("Created %s\n", projectFile);
     tbx_printf("Fill in 'description' and 'platforms' URLs, then run 'tbxmanager lock'.\n");
-    tbx_printf("To publish, add the tbxmanager-publish workflow to .github/workflows/.\n");
+    tbx_printf("To publish, run 'tbxmanager publish' from this directory.\n");
 end
 
 %% ========================================================================
@@ -2227,6 +2229,235 @@ end
 %  Command: help
 %  ========================================================================
 
+function main_publish(~)
+%MAIN_PUBLISH  Publish package to the tbxmanager registry.
+%   Reads tbxmanager.json, builds an archive, creates a GitHub release,
+%   uploads the archive, and submits a registry issue.
+    REGISTRY_REPO = "MarekWadinger/tbxmanager-registry";
+
+    % 1. Read and validate tbxmanager.json
+    projectFile = fullfile(pwd, "tbxmanager.json");
+    if ~isfile(projectFile)
+        tbx_printError("No tbxmanager.json found. Run 'tbxmanager init' first.");
+        return;
+    end
+    pkg = tbx_readJson(projectFile);
+    for f = ["name", "version", "description", "platforms"]
+        if ~isfield(pkg, f)
+            tbx_printError("tbxmanager.json missing required field: %s", f);
+            return;
+        end
+    end
+    name = string(pkg.name);
+    ver = string(pkg.version);
+    tbx_printf("Publishing %s v%s\n\n", name, ver);
+
+    % 2. Determine platform
+    platNames = string(fieldnames(pkg.platforms));
+    if isscalar(platNames)
+        platform = platNames(1);
+    else
+        tbx_printf("Platforms: %s\n", strjoin(platNames, ", "));
+        tbx_printError("Multi-platform publish not yet supported. Publish each platform separately.");
+        return;
+    end
+
+    % 3. Get GitHub token
+    token = tbx_getGithubToken();
+    if token == ""
+        return;
+    end
+
+    % 4. Parse repository URL from homepage
+    if isfield(pkg, "homepage")
+        repoUrl = string(pkg.homepage);
+    else
+        repoUrl = string(input("GitHub repository URL: ", "s"));
+    end
+    parts = split(replace(repoUrl, "https://github.com/", ""), "/");
+    if numel(parts) < 2
+        tbx_printError("Invalid GitHub URL: %s", repoUrl);
+        return;
+    end
+    owner = parts(1);
+    repo = parts(2);
+
+    % 5. Build archive
+    excludes = [".git", ".github", "tests", "docs", "tbxmanager.json"];
+    if isfield(pkg, "publish") && isfield(pkg.publish, "exclude")
+        excludes = string(pkg.publish.exclude);
+    end
+    archiveName = name + "-" + platform + ".zip";
+    archivePath = fullfile(tempdir, archiveName);
+    tbx_printf("Building archive...");
+    tbx_buildArchive(archivePath, excludes);
+    d = dir(archivePath);
+    tbx_printf(" done (%s, %d KB)\n", archiveName, round(d.bytes / 1024));
+
+    % 6. Compute SHA256
+    hash = tbx_sha256(archivePath);
+    tbx_printf("SHA256: %s\n", hash);
+
+    % 7. Create or find GitHub release
+    tag = "v" + ver;
+    apiBase = "https://api.github.com/repos/" + owner + "/" + repo;
+    tbx_printf("Creating release %s...", tag);
+    try
+        releaseBody.tag_name = char(tag);
+        releaseBody.name = char(tag);
+        releaseBody.draft = false;
+        releaseBody.prerelease = false;
+        release = tbx_githubApi("POST", apiBase + "/releases", token, releaseBody);
+        tbx_printf(" done\n");
+    catch ME
+        if contains(ME.message, "already_exists") || contains(ME.message, "422")
+            tbx_printf(" already exists, reusing\n");
+            release = tbx_githubApi("GET", apiBase + "/releases/tags/" + tag, token);
+        else
+            tbx_printError("Failed to create release: %s", ME.message);
+            return;
+        end
+    end
+
+    % 8. Upload archive to release
+    uploadUrl = string(release.upload_url);
+    uploadUrl = replace(uploadUrl, "{?name,label}", "");
+    uploadUrl = uploadUrl + "?name=" + archiveName;
+    tbx_printf("Uploading archive...");
+    try
+        fid = fopen(archivePath, 'r');
+        cleanObj = onCleanup(@() fclose(fid));
+        data = fread(fid, '*uint8')';
+        opts = weboptions( ...
+            'MediaType', 'application/zip', ...
+            'HeaderFields', {'Authorization', "token " + token; ...
+                             'Content-Type', 'application/zip'}, ...
+            'Timeout', 300);
+        webwrite(uploadUrl, data, opts);
+        tbx_printf(" done\n");
+    catch ME
+        if contains(ME.message, "already_exists")
+            tbx_printf(" already uploaded\n");
+        else
+            tbx_printError("Failed to upload: %s", ME.message);
+            return;
+        end
+    end
+
+    % 9. Submit to registry via issue
+    assetUrl = "https://github.com/" + owner + "/" + repo + ...
+               "/releases/download/" + tag + "/" + archiveName;
+    if platform == "all"
+        platformLabel = "all (pure MATLAB, no MEX files)";
+    else
+        platformLabel = platform;
+    end
+    issueBody = sprintf("### Repository URL\n\n%s\n\n### Release tag\n\n%s\n\n### Platform\n\n%s", ...
+        "https://github.com/" + owner + "/" + repo, tag, platformLabel);
+    issueData.title = char("Submit: " + name + "@" + ver);
+    issueData.body = char(issueBody);
+    issueData.labels = {'submit-package'};
+    tbx_printf("Submitting to registry...");
+    try
+        issue = tbx_githubApi("POST", ...
+            "https://api.github.com/repos/" + REGISTRY_REPO + "/issues", ...
+            token, issueData);
+        tbx_printf(" done\n\n");
+        tbx_printf("Submission created! A maintainer will review your package.\n");
+        tbx_printf("Track progress: %s\n", string(issue.html_url));
+    catch ME
+        tbx_printError("Failed to submit: %s", ME.message);
+    end
+
+    % Cleanup
+    delete(archivePath);
+end
+
+function token = tbx_getGithubToken()
+%TBX_GETGITHUBTOKEN  Get GitHub token from config or prompt user.
+    cfgFile = fullfile(tbx_baseDir(), "config.json");
+    cfg = tbx_config();
+    if isfield(cfg, "github_token") && strlength(string(cfg.github_token)) > 0
+        token = string(cfg.github_token);
+        return;
+    end
+    tbx_printf("GitHub token not configured.\n");
+    tbx_printf("Create a classic token with 'public_repo' scope at:\n");
+    tbx_printf("  https://github.com/settings/tokens/new?scopes=public_repo\n\n");
+    tokenStr = input("Enter token (or press Enter to cancel): ", "s");
+    if isempty(tokenStr)
+        token = "";
+        return;
+    end
+    token = string(tokenStr);
+    cfg.github_token = char(token);
+    tbx_writeJson(cfgFile, cfg);
+    tbx_printf("Token saved to config.\n\n");
+end
+
+function resp = tbx_githubApi(method, url, token, body)
+%TBX_GITHUBAPI  Make an authenticated GitHub API request.
+    arguments
+        method (1,1) string
+        url (1,1) string
+        token (1,1) string
+        body = []
+    end
+    opts = weboptions( ...
+        'HeaderFields', {'Authorization', "token " + token; ...
+                         'Accept', 'application/vnd.github+json'}, ...
+        'Timeout', 60, ...
+        'ContentType', 'json');
+    if method == "GET"
+        resp = webread(url, opts);
+    else
+        if isempty(body)
+            resp = webwrite(url, opts);
+        else
+            resp = webwrite(url, body, opts);
+        end
+    end
+end
+
+function tbx_buildArchive(archivePath, excludePatterns)
+%TBX_BUILDARCHIVE  Build a zip archive of the current directory.
+    arguments
+        archivePath (1,1) string
+        excludePatterns (1,:) string
+    end
+    allFiles = dir(fullfile(pwd, '**', '*'));
+    allFiles = allFiles(~[allFiles.isdir]);
+    baseDir = pwd;
+    keep = {};
+    for i = 1:numel(allFiles)
+        relPath = strrep(fullfile(allFiles(i).folder, allFiles(i).name), ...
+                         [baseDir filesep], '');
+        excluded = false;
+        for j = 1:numel(excludePatterns)
+            pat = excludePatterns(j);
+            if startsWith(relPath, pat) || startsWith(relPath, pat + filesep)
+                excluded = true;
+                break;
+            end
+            if contains(pat, "*")
+                % Glob pattern like "*.mat"
+                ext = extractAfter(pat, "*");
+                if endsWith(relPath, ext)
+                    excluded = true;
+                    break;
+                end
+            end
+        end
+        if ~excluded
+            keep{end+1} = fullfile(allFiles(i).folder, allFiles(i).name); %#ok<AGROW>
+        end
+    end
+    if isempty(keep)
+        error("TBXMANAGER:EmptyArchive", "No files to archive after applying exclusions.");
+    end
+    zip(archivePath, keep, baseDir);
+end
+
 function main_help(args)
 %MAIN_HELP  Display help text.
     if ~isempty(args)
@@ -2343,6 +2574,16 @@ function main_help(args)
             tbx_printf("  tbxmanager cache list    Show cached files\n");
             tbx_printf("  tbxmanager cache clean   Remove all cached files\n");
 
+        case "publish"
+            tbx_printf("tbxmanager publish - Publish package to the registry\n\n");
+            tbx_printf("Usage:\n");
+            tbx_printf("  tbxmanager publish\n\n");
+            tbx_printf("Reads tbxmanager.json from the current directory, builds a zip\n");
+            tbx_printf("archive, creates a GitHub release, uploads the archive, and\n");
+            tbx_printf("submits a package to the tbxmanager registry.\n\n");
+            tbx_printf("Requires a GitHub token with 'public_repo' scope.\n");
+            tbx_printf("The token is prompted on first use and saved to config.\n");
+
         otherwise
             tbx_printf("tbxmanager v2.0 - MATLAB Package Manager\n\n");
             tbx_printf("Usage: tbxmanager <command> [arguments]\n\n");
@@ -2355,6 +2596,7 @@ function main_help(args)
             tbx_printf("  info          Show package details\n");
             tbx_printf("\nProject commands:\n");
             tbx_printf("  init          Create tbxmanager.json template\n");
+            tbx_printf("  publish       Publish package to the registry\n");
             tbx_printf("  lock          Generate tbxmanager.lock from tbxmanager.json\n");
             tbx_printf("  sync          Install from tbxmanager.lock\n");
             tbx_printf("\nPath commands:\n");

--- a/tests/TestInternal.m
+++ b/tests/TestInternal.m
@@ -1,0 +1,162 @@
+classdef TestInternal < matlab.unittest.TestCase
+    % Tests for the internal__ dispatch mechanism that exposes internal
+    % functions for testing.
+
+    properties
+        TempDir
+        OrigHome
+        OrigDir
+    end
+
+    methods (TestMethodSetup)
+        function setupTest(testCase)
+            testCase.TempDir = fullfile(tempdir, "tbx_test_" + string(randi(99999)));
+            mkdir(testCase.TempDir);
+            testCase.OrigHome = getenv("TBXMANAGER_HOME");
+            testCase.OrigDir = pwd;
+            setenv("TBXMANAGER_HOME", testCase.TempDir);
+
+            % Initialize tbxmanager
+            evalc('tbxmanager("help")');
+
+            testCase.addTeardown(@() rmdir(testCase.TempDir, 's'));
+            testCase.addTeardown(@() cd(testCase.OrigDir));
+            testCase.addTeardown(@() setenv("TBXMANAGER_HOME", testCase.OrigHome));
+        end
+    end
+
+    methods (Test)
+
+        % --- parseVersion ---
+
+        function testInternalParseVersion(testCase)
+            result = tbxmanager("internal__", "parseVersion", "1.2.3");
+            testCase.verifyEqual(result, [1 2 3], ...
+                'parseVersion("1.2.3") should return [1 2 3]');
+        end
+
+        function testInternalParseVersionTwoPart(testCase)
+            result = tbxmanager("internal__", "parseVersion", "3.7");
+            testCase.verifyEqual(result, [3 7 0], ...
+                'parseVersion("3.7") should return [3 7 0]');
+        end
+
+        % --- sha256 ---
+
+        function testInternalSha256(testCase)
+            tmpFile = fullfile(testCase.TempDir, "hashtest.txt");
+            fid = fopen(tmpFile, 'w');
+            fprintf(fid, 'hello world');
+            fclose(fid);
+            result = tbxmanager("internal__", "sha256", tmpFile);
+            testCase.verifyTrue(ischar(result) || isstring(result), ...
+                'sha256 should return a string');
+            testCase.verifyEqual(strlength(string(result)), 64, ...
+                'SHA256 hash should be 64 hex characters');
+        end
+
+        function testInternalSha256Deterministic(testCase)
+            tmpFile = fullfile(testCase.TempDir, "hashdet.txt");
+            fid = fopen(tmpFile, 'w');
+            fprintf(fid, 'deterministic test content');
+            fclose(fid);
+            result1 = tbxmanager("internal__", "sha256", tmpFile);
+            result2 = tbxmanager("internal__", "sha256", tmpFile);
+            testCase.verifyEqual(string(result1), string(result2), ...
+                'Same file should produce same hash');
+        end
+
+        % --- baseDir ---
+
+        function testInternalBaseDir(testCase)
+            result = tbxmanager("internal__", "baseDir");
+            testCase.verifyTrue(ischar(result) || isstring(result), ...
+                'baseDir should return a string');
+            testCase.verifyTrue(strlength(string(result)) > 0, ...
+                'baseDir should not be empty');
+            testCase.verifyTrue(isfolder(result), ...
+                'baseDir should be an existing directory');
+        end
+
+        % --- platformArch ---
+
+        function testInternalPlatformArch(testCase)
+            result = tbxmanager("internal__", "platformArch");
+            validPlatforms = ["win64", "maci64", "maca64", "glnxa64"];
+            testCase.verifyTrue(ismember(string(result), validPlatforms), ...
+                'platformArch should return a known platform');
+        end
+
+        % --- unknown function ---
+
+        function testInternalUnknownFunction(testCase)
+            testCase.verifyError( ...
+                @() tbxmanager("internal__", "nonexistent_func_xyz"), ...
+                'TBXMANAGER:Internal');
+        end
+
+        % --- no arguments ---
+
+        function testInternalNoArgs(testCase)
+            testCase.verifyError( ...
+                @() tbxmanager("internal__"), ...
+                'TBXMANAGER:Internal');
+        end
+
+        % --- compareVersions ---
+
+        function testInternalCompareVersions(testCase)
+            result = tbxmanager("internal__", "compareVersions", "1.0.0", "2.0.0");
+            testCase.verifyEqual(result, -1, '1.0.0 should be less than 2.0.0');
+        end
+
+        function testInternalCompareVersionsEqual(testCase)
+            result = tbxmanager("internal__", "compareVersions", "1.2.3", "1.2.3");
+            testCase.verifyEqual(result, 0, 'Same versions should be equal');
+        end
+
+        function testInternalCompareVersionsGreater(testCase)
+            result = tbxmanager("internal__", "compareVersions", "3.0.0", "1.0.0");
+            testCase.verifyEqual(result, 1, '3.0.0 should be greater than 1.0.0');
+        end
+
+        % --- satisfiesConstraint ---
+
+        function testInternalSatisfiesConstraint(testCase)
+            result = tbxmanager("internal__", "satisfiesConstraint", "1.5.0", ">=1.0");
+            testCase.verifyTrue(logical(result), '1.5.0 should satisfy >=1.0');
+        end
+
+        function testInternalSatisfiesConstraintFails(testCase)
+            result = tbxmanager("internal__", "satisfiesConstraint", "0.9.0", ">=1.0");
+            testCase.verifyFalse(logical(result), '0.9.0 should not satisfy >=1.0');
+        end
+
+        function testInternalSatisfiesConstraintWildcard(testCase)
+            result = tbxmanager("internal__", "satisfiesConstraint", "99.0.0", "*");
+            testCase.verifyTrue(logical(result), 'Any version should satisfy wildcard');
+        end
+
+        % --- listInstalled ---
+
+        function testInternalListInstalledEmpty(testCase)
+            result = tbxmanager("internal__", "listInstalled");
+            testCase.verifyTrue(isempty(result), ...
+                'listInstalled should be empty with no packages');
+        end
+
+        % --- readJson / writeJson ---
+
+        function testInternalReadWriteJson(testCase)
+            jsonFile = fullfile(testCase.TempDir, "test_rw.json");
+            data = struct("key1", "value1", "key2", 42);
+            evalc('tbxmanager("internal__", "writeJson", jsonFile, jsonencode(data))');
+            testCase.verifyTrue(isfile(jsonFile), 'JSON file should exist');
+
+            result = tbxmanager("internal__", "readJson", jsonFile);
+            testCase.verifyEqual(string(result.key1), "value1");
+            testCase.verifyEqual(result.key2, 42);
+        end
+
+    end
+end

--- a/tests/TestLockSync.m
+++ b/tests/TestLockSync.m
@@ -1,0 +1,251 @@
+classdef TestLockSync < matlab.unittest.TestCase
+    % Tests for lock and sync commands with mock packages.
+
+    properties
+        TempDir
+        OrigHome
+        OrigDir
+        OrigPath
+        MockIndexFile
+        MockPkgDir
+        ProjectDir
+    end
+
+    methods (TestMethodSetup)
+        function setupTest(testCase)
+            testCase.TempDir = fullfile(tempdir, "tbx_test_" + string(randi(99999)));
+            mkdir(testCase.TempDir);
+            testCase.OrigHome = getenv("TBXMANAGER_HOME");
+            testCase.OrigDir = pwd;
+            testCase.OrigPath = path;
+            setenv("TBXMANAGER_HOME", testCase.TempDir);
+
+            % Ensure tbxmanager stays on path after cd
+            tbxFile = which("tbxmanager");
+            if ~isempty(tbxFile)
+                addpath(fileparts(tbxFile));
+            end
+
+            testCase.MockPkgDir = fullfile(testCase.TempDir, "mock_packages");
+            mkdir(testCase.MockPkgDir);
+            testCase.MockIndexFile = fullfile(testCase.TempDir, "mock_index.json");
+
+            % Initialize tbxmanager
+            evalc('tbxmanager("help")');
+
+            % Create mock packages and index
+            testCase.createMockPackages();
+            testCase.createMockIndex();
+
+            % Point tbxmanager to local mock index
+            srcUrl = char("file://" + replace(string(testCase.MockIndexFile), "\", "/"));
+            evalc('tbxmanager("source", "remove", "https://marekwadinger.github.io/tbxmanager-registry/index.json")');
+            evalc('tbxmanager("source", "add", srcUrl)');
+
+            % Create project directory with tbxmanager.json
+            testCase.ProjectDir = fullfile(testCase.TempDir, "project");
+            mkdir(testCase.ProjectDir);
+            projData = struct();
+            projData.name = 'myproject';
+            projData.version = '0.1.0';
+            projData.dependencies = struct('testpkg2', '>=1.0');
+            fid = fopen(fullfile(testCase.ProjectDir, "tbxmanager.json"), 'w');
+            fprintf(fid, '%s', jsonencode(projData));
+            fclose(fid);
+
+            % Teardowns run LIFO
+            testCase.addTeardown(@() rmdir(testCase.TempDir, 's'));
+            testCase.addTeardown(@() cd(testCase.OrigDir));
+            testCase.addTeardown(@() path(testCase.OrigPath));
+            testCase.addTeardown(@() setenv("TBXMANAGER_HOME", testCase.OrigHome));
+        end
+    end
+
+    methods (Access = private)
+        function createMockPackages(testCase)
+            % Create testpkg1 v1.0.0
+            d = fullfile(testCase.MockPkgDir, "testpkg1_v1");
+            mkdir(d);
+            fid = fopen(fullfile(d, "testpkg1_hello.m"), 'w');
+            fprintf(fid, 'function testpkg1_hello()\ndisp(''hello from testpkg1 v1'');\nend\n');
+            fclose(fid);
+            zip(fullfile(testCase.MockPkgDir, "testpkg1-1.0.0-all.zip"), '*', d);
+
+            % Create testpkg2 v2.0.0 (depends on testpkg1)
+            d2 = fullfile(testCase.MockPkgDir, "testpkg2_v2");
+            mkdir(d2);
+            fid = fopen(fullfile(d2, "testpkg2_hello.m"), 'w');
+            fprintf(fid, 'function testpkg2_hello()\ndisp(''hello from testpkg2 v2'');\nend\n');
+            fclose(fid);
+            zip(fullfile(testCase.MockPkgDir, "testpkg2-2.0.0-all.zip"), '*', d2);
+        end
+
+        function hash = computeSha256(~, filepath)
+            md = java.security.MessageDigest.getInstance("SHA-256");
+            fid = fopen(filepath, 'r');
+            while ~feof(fid)
+                chunk = fread(fid, 65536, '*uint8');
+                if ~isempty(chunk)
+                    md.update(chunk);
+                end
+            end
+            fclose(fid);
+            hashBytes = md.digest();
+            hexChars = '0123456789abcdef';
+            hash = blanks(length(hashBytes) * 2);
+            for i = 1:length(hashBytes)
+                b = typecast(int8(hashBytes(i)), 'uint8');
+                hash((i-1)*2 + 1) = hexChars(bitshift(b, -4) + 1);
+                hash((i-1)*2 + 2) = hexChars(bitand(b, 15) + 1);
+            end
+        end
+
+        function s = jsonEscape(~, s0)
+            s = char(s0);
+            s = strrep(s, '\', '\\');
+            s = strrep(s, '"', '\"');
+        end
+
+        function createMockIndex(testCase)
+            d = testCase.MockPkgDir;
+
+            h1v1 = testCase.computeSha256(fullfile(d, "testpkg1-1.0.0-all.zip"));
+            h2v2 = testCase.computeSha256(fullfile(d, "testpkg2-2.0.0-all.zip"));
+
+            u1v1 = char("file://" + replace(string(fullfile(d, "testpkg1-1.0.0-all.zip")), "\", "/"));
+            u2v2 = char("file://" + replace(string(fullfile(d, "testpkg2-2.0.0-all.zip")), "\", "/"));
+
+            fmt = @(s) strrep(testCase.jsonEscape(s), '%', '%%');
+            vfmt = @(u,h,r) sprintf('{"matlab":">=R2022a","dependencies":{},"platforms":{"all":{"url":"%s","sha256":"%s"}},"released":"%s"}', ...
+                fmt(u), fmt(h), fmt(r));
+            v2dep = sprintf('{"matlab":">=R2022a","dependencies":{"testpkg1":">=1.0"},"platforms":{"all":{"url":"%s","sha256":"%s"}},"released":"2025-03-01"}', ...
+                fmt(u2v2), fmt(h2v2));
+
+            json = [...
+                '{' ...
+                    '"index_version":1,' ...
+                    '"generated":"2026-01-01T00:00:00Z",' ...
+                    '"packages":{' ...
+                        '"testpkg1":{"name":"testpkg1","description":"Test package 1","license":"MIT","authors":["Test"],"latest":"1.0.0",' ...
+                        '"versions":{"1.0.0":' vfmt(u1v1, h1v1, '2025-01-01') '}},' ...
+                        '"testpkg2":{"name":"testpkg2","description":"Test package 2","license":"MIT","authors":["Test"],"latest":"2.0.0",' ...
+                        '"versions":{"2.0.0":' v2dep '}}' ...
+                    '}' ...
+                '}'];
+
+            fid = fopen(testCase.MockIndexFile, 'w');
+            fprintf(fid, '%s', json);
+            fclose(fid);
+        end
+    end
+
+    methods (Test)
+
+        % --- lock errors ---
+
+        function testLockNoProjectFile(testCase)
+            emptyDir = fullfile(testCase.TempDir, "empty_project");
+            mkdir(emptyDir);
+            cd(emptyDir);
+            out = evalc('tbxmanager("lock")');
+            testCase.verifyTrue(contains(out, "tbxmanager.json") || contains(out, "No"), ...
+                'Should report missing project file');
+        end
+
+        function testLockCreatesLockFile(testCase)
+            cd(testCase.ProjectDir);
+            evalc('tbxmanager("lock")');
+            lockFile = fullfile(testCase.ProjectDir, "tbxmanager.lock");
+            testCase.verifyTrue(isfile(lockFile), 'Lock file should be created');
+        end
+
+        function testLockResolvesPackage(testCase)
+            cd(testCase.ProjectDir);
+            evalc('tbxmanager("lock")');
+            lockFile = fullfile(testCase.ProjectDir, "tbxmanager.lock");
+            lockData = jsondecode(fileread(lockFile));
+            testCase.verifyTrue(isfield(lockData, 'packages'), 'Lock should have packages field');
+            testCase.verifyTrue(isfield(lockData.packages, 'testpkg2'), ...
+                'Lock should contain testpkg2');
+        end
+
+        function testLockResolvesWithDeps(testCase)
+            cd(testCase.ProjectDir);
+            evalc('tbxmanager("lock")');
+            lockFile = fullfile(testCase.ProjectDir, "tbxmanager.lock");
+            lockData = jsondecode(fileread(lockFile));
+            testCase.verifyTrue(isfield(lockData.packages, 'testpkg1'), ...
+                'Lock should contain dependency testpkg1');
+            testCase.verifyTrue(isfield(lockData.packages, 'testpkg2'), ...
+                'Lock should contain testpkg2');
+        end
+
+        function testLockContainsSha256(testCase)
+            cd(testCase.ProjectDir);
+            evalc('tbxmanager("lock")');
+            lockFile = fullfile(testCase.ProjectDir, "tbxmanager.lock");
+            lockData = jsondecode(fileread(lockFile));
+            pkg = lockData.packages.testpkg2;
+            testCase.verifyTrue(isfield(pkg, 'resolved') && isfield(pkg.resolved, 'sha256'), ...
+                'Lock entry should have sha256');
+            testCase.verifyEqual(strlength(string(pkg.resolved.sha256)), 64, ...
+                'SHA256 should be 64 hex characters');
+        end
+
+        function testLockContainsUrl(testCase)
+            cd(testCase.ProjectDir);
+            evalc('tbxmanager("lock")');
+            lockFile = fullfile(testCase.ProjectDir, "tbxmanager.lock");
+            lockData = jsondecode(fileread(lockFile));
+            pkg = lockData.packages.testpkg2;
+            testCase.verifyTrue(isfield(pkg, 'resolved') && isfield(pkg.resolved, 'url'), ...
+                'Lock entry should have url');
+            testCase.verifyTrue(strlength(string(pkg.resolved.url)) > 0, ...
+                'URL should not be empty');
+        end
+
+        % --- sync errors ---
+
+        function testSyncNoLockFile(testCase)
+            emptyDir = fullfile(testCase.TempDir, "empty_sync");
+            mkdir(emptyDir);
+            cd(emptyDir);
+            out = evalc('tbxmanager("sync")');
+            testCase.verifyTrue(contains(out, "lock") || contains(out, "No"), ...
+                'Should report missing lock file');
+        end
+
+        function testSyncInstallsFromLock(testCase)
+            cd(testCase.ProjectDir);
+            evalc('tbxmanager("lock")');
+            evalc('tbxmanager("sync")');
+            testCase.verifyTrue( ...
+                isfolder(fullfile(testCase.TempDir, "packages", "testpkg2")), ...
+                'testpkg2 should be installed after sync');
+            testCase.verifyTrue( ...
+                isfolder(fullfile(testCase.TempDir, "packages", "testpkg1")), ...
+                'testpkg1 (dependency) should be installed after sync');
+        end
+
+        function testSyncSkipsUpToDate(testCase)
+            cd(testCase.ProjectDir);
+            evalc('tbxmanager("lock")');
+            evalc('tbxmanager("sync")');
+            out = evalc('tbxmanager("sync")');
+            testCase.verifyTrue(contains(out, "up to date"), ...
+                'Second sync should report up to date');
+        end
+
+        function testLockThenSyncRoundtrip(testCase)
+            cd(testCase.ProjectDir);
+            evalc('tbxmanager("lock")');
+            evalc('tbxmanager("sync")');
+            out = evalc('tbxmanager("list")');
+            testCase.verifyTrue(contains(out, "testpkg2"), ...
+                'List should show testpkg2 after lock+sync');
+            testCase.verifyTrue(contains(out, "testpkg1"), ...
+                'List should show testpkg1 after lock+sync');
+        end
+
+    end
+end

--- a/tests/TestPublish.m
+++ b/tests/TestPublish.m
@@ -1,0 +1,200 @@
+classdef TestPublish < matlab.unittest.TestCase
+    % Tests for publish command validation and archive building.
+    % Does NOT make actual GitHub API calls.
+
+    properties
+        TempDir
+        OrigHome
+        OrigDir
+        OrigPath
+    end
+
+    methods (TestMethodSetup)
+        function setupTest(testCase)
+            testCase.TempDir = fullfile(tempdir, "tbx_test_" + string(randi(99999)));
+            mkdir(testCase.TempDir);
+            testCase.OrigHome = getenv("TBXMANAGER_HOME");
+            testCase.OrigDir = pwd;
+            testCase.OrigPath = path;
+            setenv("TBXMANAGER_HOME", testCase.TempDir);
+
+            % Ensure tbxmanager stays on path after cd
+            tbxFile = which("tbxmanager");
+            if ~isempty(tbxFile)
+                addpath(fileparts(tbxFile));
+            end
+
+            % Initialize tbxmanager
+            evalc('tbxmanager("help")');
+
+            testCase.addTeardown(@() rmdir(testCase.TempDir, 's'));
+            testCase.addTeardown(@() cd(testCase.OrigDir));
+            testCase.addTeardown(@() path(testCase.OrigPath));
+            testCase.addTeardown(@() setenv("TBXMANAGER_HOME", testCase.OrigHome));
+        end
+    end
+
+    methods (Access = private)
+        function projectDir = createMockProject(testCase, pkgJson)
+            % Create a mock project directory with given tbxmanager.json content,
+            % some .m files, a .mat file, and a .git directory.
+            projectDir = fullfile(testCase.TempDir, "project_" + string(randi(99999)));
+            mkdir(projectDir);
+
+            % Write tbxmanager.json
+            fid = fopen(fullfile(projectDir, "tbxmanager.json"), 'w');
+            fprintf(fid, '%s', jsonencode(pkgJson));
+            fclose(fid);
+
+            % Create .m files
+            fid = fopen(fullfile(projectDir, "myfunc.m"), 'w');
+            fprintf(fid, 'function myfunc()\ndisp(''hello'');\nend\n');
+            fclose(fid);
+
+            fid = fopen(fullfile(projectDir, "helper.m"), 'w');
+            fprintf(fid, 'function helper()\ndisp(''helper'');\nend\n');
+            fclose(fid);
+
+            % Create .mat file
+            fid = fopen(fullfile(projectDir, "data.mat"), 'w');
+            fwrite(fid, uint8(zeros(1, 64)));
+            fclose(fid);
+
+            % Create .git directory with a dummy file
+            gitDir = fullfile(projectDir, ".git");
+            mkdir(gitDir);
+            fid = fopen(fullfile(gitDir, "config"), 'w');
+            fprintf(fid, '[core]\nrepositoryformatversion = 0\n');
+            fclose(fid);
+        end
+
+        function pkg = validPkgJson(~)
+            pkg = struct();
+            pkg.name = 'testpkg';
+            pkg.version = '1.0.0';
+            pkg.description = 'A test package';
+            platforms = struct('all', struct());
+            pkg.platforms = platforms;
+        end
+    end
+
+    methods (Test)
+
+        % --- Validation errors ---
+
+        function testPublishNoProjectFile(testCase)
+            emptyDir = fullfile(testCase.TempDir, "empty_pub");
+            mkdir(emptyDir);
+            cd(emptyDir);
+            out = evalc('tbxmanager("publish")');
+            testCase.verifyTrue( ...
+                contains(out, "tbxmanager.json") || contains(out, "No"), ...
+                'Should report missing tbxmanager.json');
+        end
+
+        function testPublishMissingName(testCase)
+            pkg = struct();
+            pkg.version = '1.0.0';
+            pkg.description = 'test';
+            pkg.platforms = struct('all', struct());
+            projectDir = fullfile(testCase.TempDir, "no_name");
+            mkdir(projectDir);
+            fid = fopen(fullfile(projectDir, "tbxmanager.json"), 'w');
+            fprintf(fid, '%s', jsonencode(pkg));
+            fclose(fid);
+            cd(projectDir);
+            out = evalc('tbxmanager("publish")');
+            testCase.verifyTrue(contains(out, "name"), ...
+                'Should report missing name field');
+        end
+
+        function testPublishMissingVersion(testCase)
+            pkg = struct();
+            pkg.name = 'testpkg';
+            pkg.description = 'test';
+            pkg.platforms = struct('all', struct());
+            projectDir = fullfile(testCase.TempDir, "no_version");
+            mkdir(projectDir);
+            fid = fopen(fullfile(projectDir, "tbxmanager.json"), 'w');
+            fprintf(fid, '%s', jsonencode(pkg));
+            fclose(fid);
+            cd(projectDir);
+            out = evalc('tbxmanager("publish")');
+            testCase.verifyTrue(contains(out, "version"), ...
+                'Should report missing version field');
+        end
+
+        function testPublishMultiPlatformError(testCase)
+            pkg = struct();
+            pkg.name = 'testpkg';
+            pkg.version = '1.0.0';
+            pkg.description = 'test';
+            pkg.platforms = struct('win64', struct(), 'maci64', struct());
+            projectDir = fullfile(testCase.TempDir, "multi_plat");
+            mkdir(projectDir);
+            fid = fopen(fullfile(projectDir, "tbxmanager.json"), 'w');
+            fprintf(fid, '%s', jsonencode(pkg));
+            fclose(fid);
+            cd(projectDir);
+            out = evalc('tbxmanager("publish")');
+            testCase.verifyTrue( ...
+                contains(out, "not yet supported") || contains(out, "separately"), ...
+                'Should report multi-platform not supported');
+        end
+
+        % --- buildArchive via internal__ ---
+
+        function testBuildArchiveCreatesZip(testCase)
+            pkg = testCase.validPkgJson();
+            projectDir = testCase.createMockProject(pkg);
+            cd(projectDir);
+            archivePath = fullfile(testCase.TempDir, "test_archive.zip");
+            evalc('tbxmanager("internal__", "buildArchive", archivePath, ".git")');
+            testCase.verifyTrue(isfile(archivePath), 'Archive zip should be created');
+        end
+
+        function testBuildArchiveExcludesPatterns(testCase)
+            pkg = testCase.validPkgJson();
+            projectDir = testCase.createMockProject(pkg);
+            cd(projectDir);
+            archivePath = fullfile(testCase.TempDir, "test_excl.zip");
+            evalc('tbxmanager("internal__", "buildArchive", archivePath, ".git")');
+
+            % List files in the zip
+            outDir = fullfile(testCase.TempDir, "unzipped_excl");
+            mkdir(outDir);
+            unzip(archivePath, outDir);
+            testCase.verifyFalse(isfolder(fullfile(outDir, ".git")), ...
+                '.git directory should be excluded from archive');
+        end
+
+        function testBuildArchiveExcludesGlob(testCase)
+            pkg = testCase.validPkgJson();
+            projectDir = testCase.createMockProject(pkg);
+            cd(projectDir);
+            archivePath = fullfile(testCase.TempDir, "test_glob.zip");
+            evalc('tbxmanager("internal__", "buildArchive", archivePath, ".git", "*.mat")');
+
+            outDir = fullfile(testCase.TempDir, "unzipped_glob");
+            mkdir(outDir);
+            unzip(archivePath, outDir);
+            matFiles = dir(fullfile(outDir, '**', '*.mat'));
+            testCase.verifyEmpty(matFiles, '.mat files should be excluded from archive');
+        end
+
+        function testBuildArchiveEmpty(testCase)
+            % Create a project with only files that will be excluded
+            projectDir = fullfile(testCase.TempDir, "only_excluded");
+            mkdir(projectDir);
+            fid = fopen(fullfile(projectDir, "data.mat"), 'w');
+            fwrite(fid, uint8(zeros(1, 16)));
+            fclose(fid);
+            cd(projectDir);
+            archivePath = fullfile(testCase.TempDir, "test_empty.zip");
+            testCase.verifyError( ...
+                @() tbxmanager("internal__", "buildArchive", archivePath, "*.mat"), ...
+                'TBXMANAGER:EmptyArchive');
+        end
+
+    end
+end

--- a/tests/TestSelfUpdate.m
+++ b/tests/TestSelfUpdate.m
@@ -1,0 +1,71 @@
+classdef TestSelfUpdate < matlab.unittest.TestCase
+    % Tests for selfupdate command. Uses file:// URLs to avoid network.
+    % IMPORTANT: Does NOT test actual file replacement to avoid destroying
+    % the real tbxmanager.m during test runs.
+
+    properties
+        TempDir
+        OrigHome
+        OrigDir
+    end
+
+    methods (TestMethodSetup)
+        function setupTest(testCase)
+            testCase.TempDir = fullfile(tempdir, "tbx_test_" + string(randi(99999)));
+            mkdir(testCase.TempDir);
+            testCase.OrigHome = getenv("TBXMANAGER_HOME");
+            testCase.OrigDir = pwd;
+            setenv("TBXMANAGER_HOME", testCase.TempDir);
+
+            % Initialize tbxmanager so config dir exists
+            evalc('tbxmanager("help")');
+
+            testCase.addTeardown(@() rmdir(testCase.TempDir, 's'));
+            testCase.addTeardown(@() cd(testCase.OrigDir));
+            testCase.addTeardown(@() setenv("TBXMANAGER_HOME", testCase.OrigHome));
+        end
+    end
+
+    methods (Access = private)
+        function setConfig(testCase, cfg)
+            cfgFile = fullfile(testCase.TempDir, "config.json");
+            fid = fopen(cfgFile, 'w');
+            fprintf(fid, '%s', jsonencode(cfg));
+            fclose(fid);
+        end
+    end
+
+    methods (Test)
+
+        function testSelfUpdateAlreadyUpToDate(testCase)
+            % Point selfupdate_url to a copy of the current tbxmanager.m.
+            % Same content = same hash = "up to date" — safe, no overwrite.
+            currentFile = string(which("tbxmanager"));
+            copyPath = fullfile(testCase.TempDir, "tbxmanager_copy.m");
+            copyfile(char(currentFile), copyPath);
+            copyUrl = "file://" + replace(string(copyPath), "\", "/");
+
+            cfg = struct("selfupdate_url", char(copyUrl));
+            testCase.setConfig(cfg);
+
+            out = evalc('tbxmanager("selfupdate")');
+            testCase.verifyTrue(contains(out, "up to date"), ...
+                'Should report already up to date when hash matches');
+        end
+
+        function testSelfUpdateBadUrl(testCase)
+            % Point to a non-existent file
+            badPath = fullfile(testCase.TempDir, "nonexistent_file.m");
+            badUrl = "file://" + replace(string(badPath), "\", "/");
+
+            cfg = struct("selfupdate_url", char(badUrl));
+            testCase.setConfig(cfg);
+
+            out = evalc('tbxmanager("selfupdate")');
+            testCase.verifyTrue( ...
+                contains(out, "Failed") || contains(out, "Error") || contains(out, "error"), ...
+                'Should report error for bad URL');
+        end
+
+    end
+end


### PR DESCRIPTION
## Summary

- **`tbxmanager publish` command** — one-command publishing like `uv publish`. Builds zip, creates GitHub release, uploads asset, submits to registry via issue form. Requires a GitHub PAT with `public_repo` scope (prompted on first use).
- **Issue-based submission** — community users submit packages via a web form on the registry. No fork, no JSON, no SHA256 needed.
- **Docs rewrite** — all author docs now lead with the issue form and `tbxmanager publish` instead of the archived `tbxmanager-publish` action.
- **36 new tests** — lock, sync, selfupdate, publish validation, archive building, internal dispatch (70 → 106 tests).
- **CI fix** — skip test/lint on `bump:` commits to avoid redundant runs.
- **Migration fix** — skip migration detection for empty `toolboxes/` directory.

## Test plan

- [x] `make test-matlab-verbose` — 106 passed
- [ ] `make test` — lint + schema validation
- [ ] `tbxmanager publish` tested end-to-end on RLS_identification repo
- [ ] Issue form submission triggers bot → PR created on registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)