### PR TITLE
docs(site): add Why tbxmanager? before/after comparison

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
     rev: v0.48.0  # autoupdated
     hooks:
       - id: markdownlint
-        args: ['--disable', 'MD013', 'MD030', 'MD033', 'MD041', '--']
+        args: ['--disable', 'MD013', 'MD030', 'MD033', 'MD041', 'MD046', '--']
         stages: [pre-commit]
         exclude: ^(CHANGELOG\.md|\.claude/)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,7 +82,7 @@ savepath
     % Done. Dependencies resolved, verified, and on your path.
     ```
 
-tbxmanager is to MATLAB what [pip](https://pip.pypa.io) is to Python or [npm](https://www.npmjs.com/) is to JavaScript — a package manager that handles downloads, dependencies, and versioning so you don't have to.
+tbxmanager is to MATLAB what [pip](https://pip.pypa.io) is to Python or npm is to JavaScript — a package manager that handles downloads, dependencies, and versioning so you don't have to.
 
 ## Quick Start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,31 @@ savepath
 
 </div>
 
+## Why tbxmanager?
+
+=== "Without tbxmanager"
+
+    ```matlab
+    % 1. Find the toolbox website, download the zip
+    % 2. Extract to some folder
+    % 3. Add to path (and hope you got the right subfolder)
+    addpath(genpath('/Users/me/Downloads/mpt-3.2.1'))
+    % 4. Repeat for every dependency...
+    addpath(genpath('/Users/me/Downloads/sedumi-1.3'))
+    addpath(genpath('/Users/me/Downloads/yalmip'))
+    % 5. Hope the versions are compatible
+    % 6. Tell your collaborator to do the same (good luck)
+    ```
+
+=== "With tbxmanager"
+
+    ```matlab
+    tbxmanager install mpt
+    % Done. Dependencies resolved, verified, and on your path.
+    ```
+
+tbxmanager is to MATLAB what [pip](https://pip.pypa.io) is to Python or [npm](https://www.npmjs.com/) is to JavaScript — a package manager that handles downloads, dependencies, and versioning so you don't have to.
+
 ## Quick Start
 
 ```matlab


### PR DESCRIPTION
## Summary
- Add a "Why tbxmanager?" section to the landing page (`docs/index.md`) between the feature cards and Quick Start
- Uses `pymdownx.tabbed` to show a side-by-side comparison: manual toolbox management vs. one-line `tbxmanager install`
- Includes an analogy line (pip for Python, npm for JavaScript) for instant understanding
- Disable MD046 in markdownlint since pymdownx.tabbed requires indented code blocks

## Test plan
- [x] `make docs-build` passes in strict mode
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)