### PR TITLE
docs(site): cross-page navigation and contributing clarity

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,6 +12,9 @@ When a PR is merged:
 
 ## Submitting a New Package
 
+!!! tip
+    The easiest way to submit a package is `tbxmanager publish` — see [Quick Start for Authors](quick-start-authors.md). The manual process below is for contributors who want to understand the registry internals or submit on behalf of others.
+
 1. **Fork** the [tbxmanager-registry](https://github.com/MarekWadinger/tbxmanager-registry) repo
 2. **Create** `packages/your-package/package.json` with the required format
 3. **Open a PR** — CI validates your submission automatically
@@ -67,3 +70,9 @@ results = runtests;
 - `tbx_` prefix for internal helpers, `main_` prefix for commands
 - MATLAB R2022a+ features only
 - Tests using `matlab.unittest.TestCase`
+
+## Next Steps
+
+- [Quick Start for Authors](quick-start-authors.md) -- publish your first package
+- [Creating Packages](creating-packages.md) -- full metadata reference
+- [Troubleshooting](troubleshooting.md) -- common issues and solutions

--- a/docs/creating-packages.md
+++ b/docs/creating-packages.md
@@ -173,7 +173,7 @@ The registry requires SHA256 hashes for integrity verification:
     ```
 
 !!! tip
-    Use the converter script to generate the registry format from your `tbxmanager.json`:
+    If you've cloned the [tbxmanager repo](https://github.com/MarekWadinger/tbxmanager) for development, you can use the converter script to generate the registry format:
     ```bash
     python scripts/convert_to_registry.py \
       --input tbxmanager.json \
@@ -181,6 +181,7 @@ The registry requires SHA256 hashes for integrity verification:
       --sha256 all=abc123... \
       --released 2026-03-28
     ```
+    This script lives in the tbxmanager repo, not in your package repo.
 
 ### Submitting to the Registry
 
@@ -217,3 +218,11 @@ The registry requires SHA256 hashes for integrity verification:
 ### Updating (Manual)
 
 To add a new version, edit your `package.json` in the registry with a new version entry and open a PR.
+
+---
+
+## Next Steps
+
+- [Quick Start for Authors](quick-start-authors.md) -- the fastest path to publishing
+- [Case Study](casestudy.md) -- real-world example with RLS_identification
+- [Contributing](contributing.md) -- how to contribute to the registry or client


### PR DESCRIPTION
## Summary

- Added tip admonition in `contributing.md` pointing users to `tbxmanager publish` before the manual registry submission steps
- Added "Next Steps" footers to `contributing.md` and `creating-packages.md` for cross-page navigation
- Clarified that the converter script lives in the tbxmanager repo, not in user package repos

## Test plan

- [x] `make docs-build` passes in strict mode
- [ ] Visual check of rendered pages on GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)