### PR TITLE
feat(client): gate index loading on index_version compatibility

### DIFF
--- a/tbxmanager.m
+++ b/tbxmanager.m
@@ -870,6 +870,19 @@ end
 %  Dependency resolver and topological sort
 %  ========================================================================
 
+function safe = tbx_safePkgFieldName(pkgName)
+%TBX_SAFEPKGFIELDNAME  Convert a package name to a MATLAB struct field name.
+%   jsondecode rewrites JSON keys that aren't valid MATLAB identifiers
+%   (e.g. "rls-identification" → "rls_identification"). User-supplied
+%   package names keep their original spelling, so any isfield or dynamic
+%   field lookup against a decoded JSON struct must pass through this
+%   helper first.
+    arguments
+        pkgName (1,1) string
+    end
+    safe = char(matlab.lang.makeValidName(char(pkgName)));
+end
+
 function plan = tbx_resolve(requested, index)
 %TBX_RESOLVE  Greedy dependency resolver with latest-version-first.
 %   requested: struct array with fields name (string), constraint (string)
@@ -909,11 +922,12 @@ function plan = tbx_resolve(requested, index)
 
 
         % Find package in index
-        if ~isfield(index.packages, char(pkgName))
+        safeName = tbx_safePkgFieldName(pkgName);
+        if ~isfield(index.packages, safeName)
             error("TBXMANAGER:PackageNotFound", ...
                 "Package '%s' not found in any index.", pkgName);
         end
-        pkgInfo = index.packages.(char(pkgName));
+        pkgInfo = index.packages.(safeName);
 
         % Get all versions sorted descending
         if ~isfield(pkgInfo, "versions")
@@ -1406,8 +1420,9 @@ function main_install(args)
     % Warn about deprecated or yanked packages
     for i = 1:numel(plan)
         pName = char(plan(i).name);
-        if isfield(index.packages, pName)
-            pkgInfo = index.packages.(pName);
+        pField = tbx_safePkgFieldName(pName);
+        if isfield(index.packages, pField)
+            pkgInfo = index.packages.(pField);
             if isfield(pkgInfo, "deprecated") && ~isempty(pkgInfo.deprecated)
                 tbx_printWarning("Package '%s' is deprecated: %s", pName, string(pkgInfo.deprecated));
             end
@@ -1836,11 +1851,12 @@ function main_update(args)
             tbx_printWarning("Package '%s' is not installed.", pkgName);
             continue;
         end
-        if ~isfield(index.packages, char(pkgName))
+        safeName = tbx_safePkgFieldName(pkgName);
+        if ~isfield(index.packages, safeName)
             tbx_printWarning("Package '%s' not found in index.", pkgName);
             continue;
         end
-        pkgInfo = index.packages.(char(pkgName));
+        pkgInfo = index.packages.(safeName);
         latestVer = "";
         if isfield(pkgInfo, "latest")
             latestVer = string(pkgInfo.latest);
@@ -2038,12 +2054,13 @@ function main_info(args)
     pkgName = args(1);
 
     index = tbx_loadIndex();
-    if ~isfield(index.packages, char(pkgName))
+    safeName = tbx_safePkgFieldName(pkgName);
+    if ~isfield(index.packages, safeName)
         tbx_printError("Package '%s' not found in any index.", pkgName);
         return;
     end
 
-    pkg = index.packages.(char(pkgName));
+    pkg = index.packages.(safeName);
 
     tbx_printf("Package: %s\n", pkgName);
     if isfield(pkg, "deprecated") && ~isempty(pkg.deprecated)

--- a/tbxmanager.m
+++ b/tbxmanager.m
@@ -745,16 +745,38 @@ function tbx_writeSources(sources)
     tbx_writeJson(sourcesFile, s);
 end
 
+function v = tbx_supportedIndexVersion()
+%TBX_SUPPORTEDINDEXVERSION  Highest index.json format version this client
+%   understands. Bump only when the client gains support for a new,
+%   breaking index format (mirrors "index_version" set by build_index.py).
+    v = 1;
+end
+
 function index = tbx_loadIndex()
 %TBX_LOADINDEX  Fetch and merge package indices from all sources.
     sources = tbx_getSources();
     index = struct();
     index.packages = struct();
+    supported = tbx_supportedIndexVersion();
     for i = 1:numel(sources)
         url = sources(i);
         try
             tbx_printf("Fetching index from %s ...\n", url);
             data = tbx_fetchJson(url);
+            % Index format gate: refuse an index newer than this client
+            % understands rather than silently mis-parsing it. A missing
+            % "index_version" is treated as version 1 for backwards compat.
+            idxVer = 1;
+            if isfield(data, "index_version") && isnumeric(data.index_version)
+                idxVer = double(data.index_version);
+            end
+            if idxVer > supported
+                tbx_printWarning(...
+                    "Index at %s uses format version %d, but this client " + ...
+                    "supports up to %d. Run 'tbxmanager selfupdate' to " + ...
+                    "upgrade. Skipping this source.", url, idxVer, supported);
+                continue;
+            end
             if isfield(data, "packages")
                 pkgNames = fieldnames(data.packages);
                 for j = 1:numel(pkgNames)
@@ -3235,6 +3257,8 @@ function result = main_internal(args)
             result = tbx_platformArch();
         case "loadIndex"
             result = tbx_loadIndex();
+        case "supportedIndexVersion"
+            result = tbx_supportedIndexVersion();
         case "resolve"
             index = tbx_loadIndex();
             requested = struct("name", {}, "constraint", {});

--- a/tests/TestInstallWorkflow.m
+++ b/tests/TestInstallWorkflow.m
@@ -180,6 +180,16 @@ classdef TestInstallWorkflow < matlab.unittest.TestCase
             fprintf(fid, 'function mcov(); end\n');
             fclose(fid);
             zip(fullfile(testCase.MockPkgDir, "testpkg_multicov-1.0.0-all.zip"), '*', d15);
+
+            % Create test-pkg-hyphen v1.0.0 — exercises the jsondecode field-name
+            % mangling fix (hyphens in JSON keys become underscores in the decoded
+            % struct, so lookups must pass through matlab.lang.makeValidName).
+            d16 = fullfile(testCase.MockPkgDir, "test-pkg-hyphen_v1");
+            mkdir(d16);
+            fid = fopen(fullfile(d16, "hyphen_func.m"), 'w');
+            fprintf(fid, 'function hyphen_func(); end\n');
+            fclose(fid);
+            zip(fullfile(testCase.MockPkgDir, "test-pkg-hyphen-1.0.0-all.zip"), '*', d16);
         end
 
         function hash = computeSha256(~, filepath)
@@ -221,6 +231,7 @@ classdef TestInstallWorkflow < matlab.unittest.TestCase
             hUpg1 = testCase.computeSha256(fullfile(d, "testpkg_upgradable-1.0.0-all.zip"));
             hUpg2 = testCase.computeSha256(fullfile(d, "testpkg_upgradable-2.0.0-all.zip"));
             hMcov = testCase.computeSha256(fullfile(d, "testpkg_multicov-1.0.0-all.zip"));
+            hHyphen = testCase.computeSha256(fullfile(d, "test-pkg-hyphen-1.0.0-all.zip"));
 
             % Build URLs
             u1v1 = char("file://" + replace(string(fullfile(d, "testpkg1-1.0.0-all.zip")), "\", "/"));
@@ -237,6 +248,7 @@ classdef TestInstallWorkflow < matlab.unittest.TestCase
             uUpg1 = char("file://" + replace(string(fullfile(d, "testpkg_upgradable-1.0.0-all.zip")), "\", "/"));
             uUpg2 = char("file://" + replace(string(fullfile(d, "testpkg_upgradable-2.0.0-all.zip")), "\", "/"));
             uMcov = char("file://" + replace(string(fullfile(d, "testpkg_multicov-1.0.0-all.zip")), "\", "/"));
+            uHyphen = char("file://" + replace(string(fullfile(d, "test-pkg-hyphen-1.0.0-all.zip")), "\", "/"));
 
             % Build deterministic raw JSON (version keys like "1.0.0" are invalid struct fields).
             fmt = @(s) strrep(testCase.jsonEscape(s), '%', '%%');
@@ -298,7 +310,9 @@ classdef TestInstallWorkflow < matlab.unittest.TestCase
                         '"testpkg_conf1":{"name":"testpkg_conf1","description":"Conflict pkg 1","license":"MIT","authors":["Test"],"latest":"1.0.0",' ...
                         '"versions":{"1.0.0":{"matlab":">=R2022a","dependencies":{"testpkg1":"==2.0.0"},"platforms":{"all":{"url":"fake://conf1","sha256":"abc123"}},"released":"2026-01-01"}}},' ...
                         '"testpkg_conf2":{"name":"testpkg_conf2","description":"Conflict pkg 2","license":"MIT","authors":["Test"],"latest":"1.0.0",' ...
-                        '"versions":{"1.0.0":{"matlab":">=R2022a","dependencies":{"testpkg1":"==1.0.0"},"platforms":{"all":{"url":"fake://conf2","sha256":"abc123"}},"released":"2026-01-01"}}}' ...
+                        '"versions":{"1.0.0":{"matlab":">=R2022a","dependencies":{"testpkg1":"==1.0.0"},"platforms":{"all":{"url":"fake://conf2","sha256":"abc123"}},"released":"2026-01-01"}}},' ...
+                        '"test-pkg-hyphen":{"name":"test-pkg-hyphen","description":"Hyphenated name","license":"MIT","authors":["Test"],"latest":"1.0.0",' ...
+                        '"versions":{"1.0.0":' vfmt(uHyphen, hHyphen, '2026-01-01') '}}' ...
                     '}' ...
                 '}'];
 
@@ -345,6 +359,16 @@ classdef TestInstallWorkflow < matlab.unittest.TestCase
             evalc('tbxmanager("install", "testpkg1")');
             pkgDir = fullfile(testCase.TempDir, "packages", "testpkg1");
             testCase.verifyTrue(isfolder(pkgDir), 'Package directory should exist');
+        end
+
+        function testInstallHyphenatedPackage(testCase)
+            % Regression test: jsondecode rewrites hyphenated JSON keys to
+            % underscored struct fields, so resolve/lookup must normalise
+            % the user-supplied name via matlab.lang.makeValidName.
+            evalc('tbxmanager("install", "test-pkg-hyphen")');
+            pkgDir = fullfile(testCase.TempDir, "packages", "test-pkg-hyphen");
+            testCase.verifyTrue(isfolder(pkgDir), ...
+                'Hyphenated package directory should exist after install');
         end
 
         function testInstallTarGzPackage(testCase)

--- a/tests/TestSourceManagement.m
+++ b/tests/TestSourceManagement.m
@@ -93,6 +93,61 @@ classdef TestSourceManagement < matlab.unittest.TestCase
             testCase.verifyTrue(true, 'Broken source should be handled by catch in loadIndex');
         end
 
+        function testSupportedIndexVersionIsOne(testCase)
+            evalc('tbxmanager("help")');
+            v = tbxmanager("internal__", "supportedIndexVersion");
+            testCase.verifyEqual(double(v), 1, ...
+                'Client should report supported index_version 1');
+        end
+
+        function testIndexVersionTooNewSkipped(testCase)
+            % An index whose index_version exceeds what the client supports
+            % must be skipped (not merged) with a warning, not silently used.
+            evalc('tbxmanager("help")');
+            supported = double(tbxmanager("internal__", "supportedIndexVersion"));
+            idxFile = fullfile(testCase.TempDir, "future_index.json");
+            idx = struct();
+            idx.index_version = supported + 1;
+            idx.packages = struct("futurepkg", struct("latest", "1.0.0"));
+            fid = fopen(idxFile, 'w');
+            fprintf(fid, '%s', jsonencode(idx));
+            fclose(fid);
+            url = "file://" + replace(string(idxFile), "\", "/");
+            s.sources = {char(url)};
+            fid = fopen(fullfile(testCase.TempDir, "state", "sources.json"), 'w');
+            fprintf(fid, '%s', jsonencode(s));
+            fclose(fid);
+
+            out = evalc('result = tbxmanager("internal__", "loadIndex");');
+            result = tbxmanager("internal__", "loadIndex");
+            testCase.verifyFalse(isfield(result.packages, "futurepkg"), ...
+                'Packages from a too-new index must not be merged');
+            testCase.verifyTrue(contains(out, "selfupdate") || contains(out, "format version"), ...
+                'Should warn that the client is too old for the index');
+        end
+
+        function testIndexVersionCurrentLoads(testCase)
+            % An index at the supported version loads normally.
+            evalc('tbxmanager("help")');
+            supported = double(tbxmanager("internal__", "supportedIndexVersion"));
+            idxFile = fullfile(testCase.TempDir, "current_index.json");
+            idx = struct();
+            idx.index_version = supported;
+            idx.packages = struct("okpkg", struct("latest", "1.0.0"));
+            fid = fopen(idxFile, 'w');
+            fprintf(fid, '%s', jsonencode(idx));
+            fclose(fid);
+            url = "file://" + replace(string(idxFile), "\", "/");
+            s.sources = {char(url)};
+            fid = fopen(fullfile(testCase.TempDir, "state", "sources.json"), 'w');
+            fprintf(fid, '%s', jsonencode(s));
+            fclose(fid);
+
+            result = tbxmanager("internal__", "loadIndex");
+            testCase.verifyTrue(isfield(result.packages, "okpkg"), ...
+                'Packages from a current-version index should be merged');
+        end
+
         function testGetSourcesScalarString(testCase)
             % Write sources.json where "sources" is a bare JSON string (not array).
             % jsondecode returns it as a char vector → ischar branch in tbx_getSources.


### PR DESCRIPTION
## Summary

Promotes `dev` to `master`. Main change: the client now respects the `index_version` field that `build_index.py` stamps into `index.json`, so a future breaking index format degrades gracefully instead of being silently mis-parsed.

## Changes
- **feat(client):** add `tbx_supportedIndexVersion()` (=1) and gate `tbx_loadIndex` — sources whose `index_version` exceeds what the client supports are skipped with a "run `tbxmanager selfupdate`" warning. Missing field treated as version 1 (back-compat). Exposed via `internal__` for testing; 3 new tests in `TestSourceManagement`.
- **fix(resolver):** look up hyphenated package names through `makeValidName` (already on `dev`).

## Verification
- `TestSourceManagement`: 11 passed
- `TestInstallWorkflow`: 61 passed (no regression on the install critical path)

Note: merging to `master` triggers `release.yml` (auto `cz bump` + GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)